### PR TITLE
Dont crash if we cant connect to host

### DIFF
--- a/tlsscan.go
+++ b/tlsscan.go
@@ -101,7 +101,9 @@ func cipherSuiteTest(cipherSuites []uint16, tlsMin uint16, tlsMax uint16, host s
 	// Quick error check
 	if err != nil {
 		// Could not connect, burn it all down!!!
-		defer conn.Close()
+		if conn != nil {
+			defer conn.Close()
+		}
 		log.Printf("Connection failed: %v", err)
 		return 0x000, false
 	}


### PR DESCRIPTION
If I run the program with `./tlsscan` and don't specify a host, and I'm not listening on that port, the program will crash because dial will return a nil connection and an err. 

This will fix that crash.